### PR TITLE
Fix setting the release flag in build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,9 @@ source:
     sha256: d305c5a8b906387752a8e19a076f1b3af1f7ec5072e8c6cee3e2bb8687779106
 
 build:
-    number: 1
+    number: 2
+    script_env:
+      - CI_QUTIP_RELEASE=1
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"  # [not win]
 
 requirements:


### PR DESCRIPTION
The first version of this release didn't set the new CI_QUTIP_RELEASE
environment variable during the build process, and consequently the
distributed version of QuTiP reported its version as `4.6.0+nogit`.  pip
versions were correct since those wheels were built on GitHub Actions
the correct way.

See qutip/qutip#1465

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
